### PR TITLE
Update versions of dependencies

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,17 +1,16 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"botan": "1.12.19",
-		"botan-math": "1.0.3",
-		"diet-ng": "1.7.4",
-		"eventcore": "0.9.13",
+		"diet-ng": "1.8.1",
+		"eventcore": "0.9.25",
 		"libasync": "0.8.6",
-		"memutils": "1.0.4",
+		"memutils": "1.0.9",
 		"mir-linux-kernel": "1.0.1",
-		"openssl": "1.1.6+1.0.1g",
+		"openssl": "3.3.0",
+		"openssl-static": "1.0.2+3.0.8",
 		"stdx-allocator": "2.77.5",
-		"taggedalgebraic": "0.11.19",
-		"vibe-core": "1.13.0",
-		"vibe-d": "0.9.3"
+		"taggedalgebraic": "0.11.22",
+		"vibe-core": "2.2.0",
+		"vibe-d": "0.9.6"
 	}
 }


### PR DESCRIPTION
Otherwise it doesn't build
```
../../.dub/packages/taggedalgebraic/0.11.19/taggedalgebraic/source/taggedalgebraic/taggedunion.d(289,62): Error: escaping reference to outer local variable `this`
```